### PR TITLE
Fix bug that unique index columns is the same as a foreign key constraint

### DIFF
--- a/src/add_fake_constraint_from_index_plugin.ts
+++ b/src/add_fake_constraint_from_index_plugin.ts
@@ -66,7 +66,10 @@ export const addFakeUniqueConstraintFromIndex = (builder: SchemaBuilder, options
       // If there already exist one, then we don't have to do it
       // if each attribute num exist in the index attribute num, then we skip it
       const exist = theClass.constraints.find(
-        c => c.keyAttributeNums.every(num => attributeNums.includes(num)),
+        (c) => {
+          return c.keyAttributeNums.every(num => attributeNums.includes(num))
+          && ['u', 'p'].includes(c.type);
+        },
       );
       if (!exist) {
         constraint.push(uniqueConstraint);


### PR DESCRIPTION
The logic skip the unique index that have the same columns as any constraint, this skips foreign key constraints. Should only skip the unique index when there is a unique constraint/primary constraint on column. 